### PR TITLE
Update ansi

### DIFF
--- a/.builds/linux.yml
+++ b/.builds/linux.yml
@@ -8,10 +8,14 @@ tasks:
       cd vte
       $HOME/.cargo/bin/cargo +stable test
       $HOME/.cargo/bin/cargo +stable test --features=ansi
+      $HOME/.cargo/bin/cargo +stable test --features=ansi --no-default-features
+      $HOME/.cargo/bin/cargo +stable test --features=ansi,no_alloc
   - clippy: |
       cd vte
       $HOME/.cargo/bin/cargo +stable clippy
       $HOME/.cargo/bin/cargo +stable clippy --features=ansi
+      $HOME/.cargo/bin/cargo +stable clippy --features=ansi --no-default-features
+      $HOME/.cargo/bin/cargo +stable clippy --features=ansi,no_alloc
   - rustfmt: |
       $HOME/.cargo/bin/rustup toolchain install nightly -c rustfmt
       cd vte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## 0.10.1
+
+- Fixed invalid intermediates when transitioning from DCS to ESC
+
 ## 0.10.0
 
 - Changed the type of CSI parameters from i64 to u16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ utf8parse = { version = "0.2.0", path = "utf8parse" }
 [features]
 ansi = ["log"]
 default = ["no_std"]
-no_std = ["arrayvec"]
+no_alloc = ["arrayvec", "no_std"]
+no_std = []
 nightly = ["utf8parse/nightly"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["parsing", "no-std"]
 exclude = ["/.travis.yml"]
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
-version = "0.10.0"
+version = "0.10.1"
 name = "vte"
 edition = "2018"
 

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -283,11 +283,11 @@ impl Processor {
                         self.state.sync_state.timeout = Some(Instant::now() + SYNC_UPDATE_TIMEOUT);
                     }
                     self.state.sync_state.in_sync = true;
-                }
+                },
                 Some(Dcs::SyncEnd) => self.stop_sync(handler, writer),
                 None => (),
             },
-            _ => {}
+            _ => {},
         }
     }
 }
@@ -669,7 +669,7 @@ impl Mode {
                 _ => {
                     trace!("[unimplemented] primitive mode: {}", num);
                     return None;
-                }
+                },
             })
         } else {
             Some(match num {
@@ -996,7 +996,7 @@ where
                 if params.iter().next().map_or(false, |param| param[0] == 1) {
                     self.state.dcs = Some(Dcs::SyncStart);
                 }
-            }
+            },
             _ => debug!(
                 "[unhandled hook] params={:?}, ints: {:?}, ignore: {:?}, action: {:?}",
                 params, intermediates, ignore, action
@@ -1018,7 +1018,7 @@ where
                     self.state.sync_state.timeout = Some(Instant::now() + SYNC_UPDATE_TIMEOUT);
                 }
                 self.state.sync_state.in_sync = true;
-            }
+            },
             Some(Dcs::SyncEnd) => (),
             _ => debug!("[unhandled unhook]"),
         }
@@ -1046,7 +1046,7 @@ where
                     return;
                 }
                 unhandled(params);
-            }
+            },
 
             // Set color index.
             b"4" => {
@@ -1061,7 +1061,7 @@ where
                     }
                 }
                 unhandled(params);
-            }
+            },
 
             // Get/set Foreground, Background, Cursor colors.
             b"10" | b"11" | b"12" => {
@@ -1096,7 +1096,7 @@ where
                     }
                 }
                 unhandled(params);
-            }
+            },
 
             // Set cursor style.
             b"50" => {
@@ -1114,7 +1114,7 @@ where
                     return;
                 }
                 unhandled(params);
-            }
+            },
 
             // Set clipboard.
             b"52" => {
@@ -1127,7 +1127,7 @@ where
                     b"?" => self.handler.clipboard_load(*clipboard, terminator),
                     base64 => self.handler.clipboard_store(*clipboard, base64),
                 }
-            }
+            },
 
             // Reset color index.
             b"104" => {
@@ -1146,7 +1146,7 @@ where
                         None => unhandled(params),
                     }
                 }
-            }
+            },
 
             // Reset foreground color.
             b"110" => self.handler.reset_color(NamedColor::Foreground as usize),
@@ -1195,7 +1195,7 @@ where
             ('@', None) => handler.insert_blank(next_param_or(1) as usize),
             ('A', None) => {
                 handler.move_up(next_param_or(1) as usize);
-            }
+            },
             ('B', None) | ('e', None) => handler.move_down(next_param_or(1) as usize),
             ('b', None) => {
                 if let Some(c) = self.state.preceding_char {
@@ -1205,11 +1205,11 @@ where
                 } else {
                     debug!("tried to repeat with no preceding char");
                 }
-            }
+            },
             ('C', None) | ('a', None) => handler.move_forward(next_param_or(1) as usize),
             ('c', intermediate) if next_param_or(0) == 0 => {
                 handler.identify_terminal(writer, intermediate.map(|&i| i as char))
-            }
+            },
             ('D', None) => handler.move_backward(next_param_or(1) as usize),
             ('d', None) => handler.goto_line(next_param_or(1) as usize - 1),
             ('E', None) => handler.move_down_and_cr(next_param_or(1) as usize),
@@ -1222,16 +1222,16 @@ where
                     _ => {
                         unhandled!();
                         return;
-                    }
+                    },
                 };
 
                 handler.clear_tabs(mode);
-            }
+            },
             ('H', None) | ('f', None) => {
                 let y = next_param_or(1) as usize;
                 let x = next_param_or(1) as usize;
                 handler.goto(y - 1, x - 1);
-            }
+            },
             ('h', intermediate) => {
                 for param in params_iter.map(|param| param[0]) {
                     match Mode::from_primitive(intermediates.get(0), param as i64) {
@@ -1239,7 +1239,7 @@ where
                         None => unhandled!(),
                     }
                 }
-            }
+            },
             ('I', None) => handler.move_forward_tabs(next_param_or(1) as i64),
             ('J', None) => {
                 let mode = match next_param_or(0) {
@@ -1250,11 +1250,11 @@ where
                     _ => {
                         unhandled!();
                         return;
-                    }
+                    },
                 };
 
                 handler.clear_screen(mode);
-            }
+            },
             ('K', None) => {
                 let mode = match next_param_or(0) {
                     0 => LineClearMode::Right,
@@ -1263,11 +1263,11 @@ where
                     _ => {
                         unhandled!();
                         return;
-                    }
+                    },
                 };
 
                 handler.clear_line(mode);
-            }
+            },
             ('L', None) => handler.insert_blank_lines(next_param_or(1) as usize),
             ('l', intermediate) => {
                 for param in params_iter.map(|param| param[0]) {
@@ -1276,7 +1276,7 @@ where
                         None => unhandled!(),
                     }
                 }
-            }
+            },
             ('M', None) => handler.delete_lines(next_param_or(1) as usize),
             ('m', None) => {
                 if params.is_empty() {
@@ -1289,7 +1289,7 @@ where
                         }
                     }
                 }
-            }
+            },
             ('n', None) => handler.device_status(writer, next_param_or(0) as usize),
             ('P', None) => handler.delete_chars(next_param_or(1) as usize),
             ('q', Some(b' ')) => {
@@ -1303,20 +1303,20 @@ where
                     _ => {
                         unhandled!();
                         return;
-                    }
+                    },
                 };
                 let cursor_style =
                     shape.map(|shape| CursorStyle { shape, blinking: cursor_style_id % 2 == 1 });
 
                 handler.set_cursor_style(cursor_style);
-            }
+            },
             ('r', None) => {
                 let top = next_param_or(1) as usize;
                 let bottom =
                     params_iter.next().map(|param| param[0] as usize).filter(|&param| param != 0);
 
                 handler.set_scrolling_region(top, bottom);
-            }
+            },
             ('S', None) => handler.scroll_up(next_param_or(1) as usize),
             ('s', None) => handler.save_cursor_position(),
             ('T', None) => handler.scroll_down(next_param_or(1) as usize),
@@ -1355,7 +1355,7 @@ where
                     _ => {
                         unhandled!();
                         return;
-                    }
+                    },
                 };
                 self.handler.configure_charset(index, $charset)
             }};
@@ -1367,14 +1367,14 @@ where
             (b'E', None) => {
                 self.handler.linefeed();
                 self.handler.carriage_return();
-            }
+            },
             (b'H', None) => self.handler.set_horizontal_tabstop(),
             (b'M', None) => self.handler.reverse_index(),
             (b'Z', None) => self.handler.identify_terminal(self.writer, None),
             (b'c', None) => self.handler.reset_state(),
             (b'0', intermediate) => {
                 configure_charset!(StandardCharset::SpecialCharacterAndLineDrawing, intermediate)
-            }
+            },
             (b'7', None) => self.handler.save_cursor_position(),
             (b'8', Some(b'#')) => self.handler.decaln(),
             (b'8', None) => self.handler.restore_cursor_position(),
@@ -1427,14 +1427,14 @@ fn attrs_from_sgr_parameters(
             [38] => {
                 let mut iter = params.map(|param| param[0]);
                 parse_sgr_color(&mut iter).map(Attr::Foreground)
-            }
+            },
             [38, params @ ..] => {
                 let rgb_start = if params.len() > 4 { 2 } else { 1 };
                 let rgb_iter = params[rgb_start..].iter().copied();
                 let mut iter = iter::once(params[0]).chain(rgb_iter);
 
                 parse_sgr_color(&mut iter).map(Attr::Foreground)
-            }
+            },
             [39] => Some(Attr::Foreground(Color::Named(NamedColor::Foreground))),
             [40] => Some(Attr::Background(Color::Named(NamedColor::Black))),
             [41] => Some(Attr::Background(Color::Named(NamedColor::Red))),
@@ -1447,14 +1447,14 @@ fn attrs_from_sgr_parameters(
             [48] => {
                 let mut iter = params.map(|param| param[0]);
                 parse_sgr_color(&mut iter).map(Attr::Background)
-            }
+            },
             [48, params @ ..] => {
                 let rgb_start = if params.len() > 4 { 2 } else { 1 };
                 let rgb_iter = params[rgb_start..].iter().copied();
                 let mut iter = iter::once(params[0]).chain(rgb_iter);
 
                 parse_sgr_color(&mut iter).map(Attr::Background)
-            }
+            },
             [49] => Some(Attr::Background(Color::Named(NamedColor::Background))),
             [90] => Some(Attr::Foreground(Color::Named(NamedColor::BrightBlack))),
             [91] => Some(Attr::Foreground(Color::Named(NamedColor::BrightRed))),

--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -4,7 +4,7 @@ use core::convert::TryFrom;
 use core::{iter, str};
 
 #[cfg(not(feature = "no_std"))]
-use str::time::{Duration, Instant};
+use std::time::{Duration, Instant};
 
 #[cfg(all(not(feature = "no_alloc"), feature = "no_std"))]
 use alloc::string::String;
@@ -338,13 +338,12 @@ impl<'a, H: Handler<W> + 'a, W> Performer<'a, H, W> {
 /// writing specific handler impls for tests far easier.
 pub trait Handler<W> {
     /// OSC to set window title.
+    #[allow(unused_variables)]
     fn set_title(&mut self, params: Option<&[&[u8]]>) {
         #[cfg(not(feature = "no_alloc"))]
         {
             #[cfg(feature = "no_std")]
             use alloc::borrow::ToOwned;
-            #[cfg(not(feature = "no_std"))]
-            use std::borrow::ToOwned;
 
             self.set_title_utf(params.map(|params| {
                 params[1..]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Parser {
                     Action::None => (),
                     action => {
                         self.perform_action(performer, action, $arg);
-                    }
+                    },
                 }
             };
         }
@@ -170,15 +170,15 @@ impl Parser {
             State::Anywhere => {
                 // Just run the action
                 self.perform_action(performer, action, byte);
-            }
+            },
             state => {
                 match self.state {
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Unhook, byte);
-                    }
+                    },
                     State::OscString => {
                         self.perform_action(performer, Action::OscEnd, byte);
-                    }
+                    },
                     _ => (),
                 }
 
@@ -187,19 +187,19 @@ impl Parser {
                 match state {
                     State::CsiEntry | State::DcsEntry | State::Escape => {
                         self.perform_action(performer, Action::Clear, byte);
-                    }
+                    },
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Hook, byte);
-                    }
+                    },
                     State::OscString => {
                         self.perform_action(performer, Action::OscStart, byte);
-                    }
+                    },
                     _ => (),
                 }
 
                 // Assume the new state
                 self.state = state;
-            }
+            },
         }
     }
 
@@ -236,12 +236,12 @@ impl Parser {
                 }
 
                 performer.hook(self.params(), self.intermediates(), self.ignoring, byte as char);
-            }
+            },
             Action::Put => performer.put(byte),
             Action::OscStart => {
                 self.osc_raw.clear();
                 self.osc_num_params = 0;
-            }
+            },
             Action::OscPut => {
                 #[cfg(feature = "no_alloc")]
                 {
@@ -262,21 +262,21 @@ impl Parser {
                         // First param is special - 0 to current byte index
                         0 => {
                             self.osc_params[param_idx] = (0, idx);
-                        }
+                        },
 
                         // All other params depend on previous indexing
                         _ => {
                             let prev = self.osc_params[param_idx - 1];
                             let begin = prev.1;
                             self.osc_params[param_idx] = (begin, idx);
-                        }
+                        },
                     }
 
                     self.osc_num_params += 1;
                 } else {
                     self.osc_raw.push(byte);
                 }
-            }
+            },
             Action::OscEnd => {
                 let param_idx = self.osc_num_params;
                 let idx = self.osc_raw.len();
@@ -289,7 +289,7 @@ impl Parser {
                     0 => {
                         self.osc_params[param_idx] = (0, idx);
                         self.osc_num_params += 1;
-                    }
+                    },
 
                     // All other params depend on previous indexing
                     _ => {
@@ -297,10 +297,10 @@ impl Parser {
                         let begin = prev.1;
                         self.osc_params[param_idx] = (begin, idx);
                         self.osc_num_params += 1;
-                    }
+                    },
                 }
                 self.osc_dispatch(performer, byte);
-            }
+            },
             Action::Unhook => performer.unhook(),
             Action::CsiDispatch => {
                 if self.params.is_full() {
@@ -315,10 +315,10 @@ impl Parser {
                     self.ignoring,
                     byte as char,
                 );
-            }
+            },
             Action::EscDispatch => {
                 performer.esc_dispatch(self.intermediates(), self.ignoring, byte)
-            }
+            },
             Action::Collect => {
                 if self.intermediate_idx == MAX_INTERMEDIATES {
                     self.ignoring = true;
@@ -326,7 +326,7 @@ impl Parser {
                     self.intermediates[self.intermediate_idx] = byte;
                     self.intermediate_idx += 1;
                 }
-            }
+            },
             Action::Param => {
                 if self.params.is_full() {
                     self.ignoring = true;
@@ -344,7 +344,7 @@ impl Parser {
                     self.param = self.param.saturating_mul(10);
                     self.param = self.param.saturating_add((byte - b'0') as u16);
                 }
-            }
+            },
             Action::Clear => {
                 // Reset everything on ESC/CSI/DCS entry
                 self.intermediate_idx = 0;
@@ -352,7 +352,7 @@ impl Parser {
                 self.param = 0;
 
                 self.params.clear();
-            }
+            },
             Action::BeginUtf8 => self.process_utf8(performer, byte),
             Action::Ignore => (),
             Action::None => (),
@@ -502,7 +502,7 @@ mod tests {
                 assert_eq!(params.len(), 2);
                 assert_eq!(params[0], &OSC_BYTES[2..3]);
                 assert_eq!(params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
-            }
+            },
             _ => panic!("expected osc sequence"),
         }
     }
@@ -539,7 +539,7 @@ mod tests {
             Sequence::Osc(params, _) => {
                 assert_eq!(params.len(), MAX_OSC_PARAMS);
                 assert!(params.iter().all(Vec::is_empty));
-            }
+            },
             _ => panic!("expected osc sequence"),
         }
     }
@@ -597,7 +597,7 @@ mod tests {
             Sequence::Osc(params, _) => {
                 assert_eq!(params[0], &[b'2']);
                 assert_eq!(params[1], &INPUT[5..(INPUT.len() - 1)]);
-            }
+            },
             _ => panic!("expected osc sequence"),
         }
     }
@@ -616,7 +616,7 @@ mod tests {
         match &dispatcher.dispatched[0] {
             Sequence::Osc(params, _) => {
                 assert_eq!(params[1], &INPUT[4..(INPUT.len() - 2)]);
-            }
+            },
             _ => panic!("expected osc sequence"),
         }
     }
@@ -656,7 +656,7 @@ mod tests {
 
                 #[cfg(feature = "no_alloc")]
                 assert_eq!(params[1].len(), MAX_OSC_RAW - params[0].len());
-            }
+            },
             _ => panic!("expected osc sequence"),
         }
     }
@@ -681,7 +681,7 @@ mod tests {
             Sequence::Csi(params, _, ignore, _) => {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(!ignore);
-            }
+            },
             _ => panic!("expected csi sequence"),
         }
     }
@@ -706,7 +706,7 @@ mod tests {
             Sequence::Csi(params, _, ignore, _) => {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(ignore);
-            }
+            },
             _ => panic!("expected csi sequence"),
         }
     }
@@ -778,7 +778,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'?']);
                 assert_eq!(params, &[[1049]]);
                 assert!(!ignore);
-            }
+            },
             _ => panic!("expected csi sequence"),
         }
     }
@@ -799,7 +799,7 @@ mod tests {
                 assert_eq!(params, &[vec![38, 2, 255, 0, 255], vec![1]]);
                 assert_eq!(intermediates, &[]);
                 assert!(!ignore);
-            }
+            },
             _ => panic!("expected csi sequence"),
         }
     }
@@ -821,7 +821,7 @@ mod tests {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(params.iter().all(|param| param == &[1]));
                 assert!(ignore);
-            }
+            },
             _ => panic!("expected dcs sequence"),
         }
     }
@@ -842,7 +842,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'$']);
                 assert_eq!(params, &[[1]]);
                 assert!(!ignore);
-            }
+            },
             _ => panic!("expected dcs sequence"),
         }
         assert_eq!(dispatcher.dispatched[1], Sequence::DcsPut(b'x'));
@@ -864,7 +864,7 @@ mod tests {
             Sequence::DcsHook(params, _, _, c) => {
                 assert_eq!(params, &[[0], [1]]);
                 assert_eq!(c, &'|');
-            }
+            },
             _ => panic!("expected dcs sequence"),
         }
         for (i, byte) in b"17/ab".iter().enumerate() {
@@ -906,7 +906,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'(']);
                 assert_eq!(*byte, b'A');
                 assert!(!ignore);
-            }
+            },
             _ => panic!("expected esc sequence"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,10 +651,10 @@ mod tests {
                 assert_eq!(params.len(), 2);
                 assert_eq!(params[0], b"52");
 
-                #[cfg(not(feature = "no_std"))]
+                #[cfg(not(feature = "no_alloc"))]
                 assert_eq!(params[1].len(), NUM_BYTES + INPUT_END.len());
 
-                #[cfg(feature = "no_std")]
+                #[cfg(feature = "no_alloc")]
                 assert_eq!(params[1].len(), MAX_OSC_RAW - params[0].len());
             },
             _ => panic!("expected osc sequence"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ use definitions::{unpack, Action, State};
 
 const MAX_INTERMEDIATES: usize = 2;
 const MAX_OSC_PARAMS: usize = 16;
-#[cfg(any(feature = "no_std", test))]
+#[cfg(any(feature = "no_alloc", test))]
 const MAX_OSC_RAW: usize = 1024;
 
 struct VtUtf8Receiver<'a, P: Perform>(&'a mut P, &'a mut State);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,323 +431,141 @@ mod tests {
     ];
 
     #[derive(Default)]
-    struct OscDispatcher {
-        dispatched_osc: bool,
-        bell_terminated: bool,
-        params: Vec<Vec<u8>>,
+    struct Dispatcher {
+        dispatched: Vec<Sequence>,
     }
 
-    // All empty bodies except osc_dispatch
-    impl Perform for OscDispatcher {
+    #[derive(Debug, PartialEq, Eq)]
+    enum Sequence {
+        Osc(Vec<Vec<u8>>, bool),
+        Csi(Vec<Vec<u16>>, Vec<u8>, bool, char),
+        Esc(Vec<u8>, bool, u8),
+        DcsHook(Vec<Vec<u16>>, Vec<u8>, bool, char),
+        DcsPut(u8),
+        DcsUnhook,
+    }
+
+    impl Perform for Dispatcher {
         fn osc_dispatch(&mut self, params: &[&[u8]], bell_terminated: bool) {
-            // Set a flag so we know these assertions all run
-            self.dispatched_osc = true;
-            self.bell_terminated = bell_terminated;
-            self.params = params.iter().map(|p| p.to_vec()).collect();
+            let params = params.iter().map(|p| p.to_vec()).collect();
+            self.dispatched.push(Sequence::Osc(params, bell_terminated));
         }
-    }
 
-    #[derive(Default)]
-    struct CsiDispatcher {
-        dispatched_csi: bool,
-        ignore: bool,
-        params: Vec<Vec<u16>>,
-        intermediates: Vec<u8>,
-    }
-
-    impl Perform for CsiDispatcher {
-        fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, _: char) {
-            self.intermediates = intermediates.to_vec();
-            self.dispatched_csi = true;
-            self.params = params.iter().map(|subparam| subparam.to_vec()).collect();
-            self.ignore = ignore;
+        fn csi_dispatch(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: char) {
+            let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::Csi(params, intermediates, ignore, c));
         }
-    }
 
-    #[derive(Default)]
-    struct DcsDispatcher {
-        dispatched_dcs: bool,
-        intermediates: Vec<u8>,
-        params: Vec<u16>,
-        ignore: bool,
-        c: Option<char>,
-        s: Vec<u8>,
-    }
+        fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::Esc(intermediates, ignore, byte));
+        }
 
-    impl Perform for DcsDispatcher {
         fn hook(&mut self, params: &Params, intermediates: &[u8], ignore: bool, c: char) {
-            self.intermediates = intermediates.to_vec();
-            self.params = params.iter().map(|x| x.to_vec()).flatten().collect();
-            self.ignore = ignore;
-            self.c = Some(c);
-            self.dispatched_dcs = true;
+            let params = params.iter().map(|subparam| subparam.to_vec()).collect();
+            let intermediates = intermediates.to_vec();
+            self.dispatched.push(Sequence::DcsHook(params, intermediates, ignore, c));
         }
 
         fn put(&mut self, byte: u8) {
-            self.s.push(byte);
+            self.dispatched.push(Sequence::DcsPut(byte));
         }
 
         fn unhook(&mut self) {
-            self.dispatched_dcs = true;
-        }
-    }
-
-    #[derive(Default)]
-    struct EscDispatcher {
-        dispatched_esc: bool,
-        intermediates: Vec<u8>,
-        ignore: bool,
-        byte: u8,
-    }
-
-    impl Perform for EscDispatcher {
-        fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
-            self.intermediates = intermediates.to_vec();
-            self.ignore = ignore;
-            self.byte = byte;
-            self.dispatched_esc = true;
+            self.dispatched.push(Sequence::DcsUnhook);
         }
     }
 
     #[test]
     fn parse_osc() {
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in OSC_BYTES {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
-        assert_eq!(dispatcher.params.len(), 2);
-        assert_eq!(dispatcher.params[0], &OSC_BYTES[2..3]);
-        assert_eq!(dispatcher.params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), 2);
+                assert_eq!(params[0], &OSC_BYTES[2..3]);
+                assert_eq!(params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
+            },
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn parse_empty_osc() {
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in &[0x1b, 0x5d, 0x07] {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(..) => (),
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn parse_osc_max_params() {
         let params = std::iter::repeat(";").take(params::MAX_PARAMS + 1).collect::<String>();
         let input = format!("\x1b]{}\x1b", &params[..]).into_bytes();
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in input {
             parser.advance(&mut dispatcher, byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.dispatched_osc);
-        assert_eq!(dispatcher.params.len(), MAX_OSC_PARAMS);
-        for param in dispatcher.params.iter() {
-            assert_eq!(param.len(), 0);
-        }
-    }
-
-    #[test]
-    fn parse_dcs_max_params() {
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS + 1).collect::<String>();
-        let input = format!("\x1bP{}p", &params[..]).into_bytes();
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
-        }
-
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert!(dispatcher.ignore);
-        assert!(dispatcher.dispatched_dcs);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        for param in dispatcher.params.iter() {
-            assert_eq!(*param, 1);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), MAX_OSC_PARAMS);
+                assert!(params.iter().all(Vec::is_empty));
+            },
+            _ => panic!("expected osc sequence"),
         }
     }
 
     #[test]
     fn osc_bell_terminated() {
         static INPUT: &[u8] = b"\x1b]11;ff/00/ff\x07";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
-        assert!(dispatcher.bell_terminated);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(_, true) => (),
+            _ => panic!("expected osc with bell terminator"),
+        }
     }
 
     #[test]
     fn osc_c0_st_terminated() {
         static INPUT: &[u8] = b"\x1b]11;ff/00/ff\x1b\\";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
-        assert!(!dispatcher.bell_terminated);
-    }
-
-    #[test]
-    fn parse_csi_max_params() {
-        // This will build a list of repeating '1;'s
-        // The length is MAX_PARAMS - 1 because the last semicolon is interpreted
-        // as an implicit zero, making the total number of parameters MAX_PARAMS
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS - 1).collect::<String>();
-        let input = format!("\x1b[{}p", &params[..]).into_bytes();
-
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
+        assert_eq!(dispatcher.dispatched.len(), 2);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(_, false) => (),
+            _ => panic!("expected osc with ST terminator"),
         }
-
-        // Check that flag is set and thus csi_dispatch assertions ran.
-        assert!(dispatcher.dispatched_csi);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        assert!(!dispatcher.ignore);
-    }
-
-    #[test]
-    fn parse_csi_params_ignore_long_params() {
-        // This will build a list of repeating '1;'s
-        // The length is MAX_PARAMS because the last semicolon is interpreted
-        // as an implicit zero, making the total number of parameters MAX_PARAMS + 1
-        let params = std::iter::repeat("1;").take(params::MAX_PARAMS).collect::<String>();
-        let input = format!("\x1b[{}p", &params[..]).into_bytes();
-
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in input {
-            parser.advance(&mut dispatcher, byte);
-        }
-
-        // Check that flag is set and thus csi_dispatch assertions ran.
-        assert!(dispatcher.dispatched_csi);
-        assert_eq!(dispatcher.params.len(), params::MAX_PARAMS);
-        assert!(dispatcher.ignore);
-    }
-
-    #[test]
-    fn parse_csi_params_trailing_semicolon() {
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in b"\x1b[4;m" {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert_eq!(dispatcher.params, &[[4], [0]]);
-    }
-
-    #[test]
-    fn parse_semi_set_underline() {
-        // Create dispatcher and check state
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in b"\x1b[;4m" {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert_eq!(dispatcher.params, &[[0], [4]]);
-    }
-
-    #[test]
-    fn parse_long_csi_param() {
-        // The important part is the parameter, which is (i64::MAX + 1)
-        static INPUT: &[u8] = b"\x1b[9223372036854775808m";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert_eq!(dispatcher.params, &[[std::u16::MAX as u16]]);
-    }
-
-    #[test]
-    fn csi_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1b[?1049h";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_csi);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'?']);
-        assert_eq!(dispatcher.params, &[[1049]]);
-    }
-
-    #[test]
-    fn csi_subparameters() {
-        static INPUT: &[u8] = b"\x1b[38:2:255:0:255;1m";
-        let mut dispatcher = CsiDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_csi);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[]);
-        assert_eq!(dispatcher.params, &[vec![38, 2, 255, 0, 255], vec![1]]);
-    }
-
-    #[test]
-    fn dcs_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1bP1$tx\x9c";
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_dcs);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'$']);
-        assert_eq!(dispatcher.params, &[1]);
-    }
-
-    #[test]
-    fn esc_reset() {
-        static INPUT: &[u8] = b"\x1b[3;1\x1b(A";
-        let mut dispatcher = EscDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
-        }
-
-        assert!(dispatcher.dispatched_esc);
-        assert!(!dispatcher.ignore);
-        assert_eq!(dispatcher.intermediates, &[b'(']);
     }
 
     #[test]
@@ -757,46 +575,40 @@ mod tests {
             0x5f, 0x28, 0xe3, 0x83, 0x84, 0x29, 0x5f, 0x2f, 0xc2, 0xaf, 0x27, 0x20, 0x26, 0x26,
             0x20, 0x73, 0x6c, 0x65, 0x65, 0x70, 0x20, 0x31, 0x07,
         ];
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        // Check that flag is set and thus osc_dispatch assertions ran.
-        assert_eq!(dispatcher.params[0], &[b'2']);
-        assert_eq!(dispatcher.params[1], &INPUT[5..(INPUT.len() - 1)]);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params[0], &[b'2']);
+                assert_eq!(params[1], &INPUT[5..(INPUT.len() - 1)]);
+            },
+            _ => panic!("expected osc sequence"),
+        }
     }
 
     #[test]
     fn osc_containing_string_terminator() {
         static INPUT: &[u8] = b"\x1b]2;\xe6\x9c\xab\x1b\\";
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         for byte in INPUT {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert_eq!(dispatcher.params[1], &INPUT[4..(INPUT.len() - 2)]);
-    }
-
-    #[test]
-    fn parse_dcs() {
-        static INPUT: &[u8] =
-            &[0x1b, 0x50, 0x30, 0x3b, 0x31, 0x7c, 0x31, 0x37, 0x2f, 0x61, 0x62, 0x9c];
-        let mut dispatcher = DcsDispatcher::default();
-        let mut parser = Parser::new();
-
-        for byte in INPUT {
-            parser.advance(&mut dispatcher, *byte);
+        assert_eq!(dispatcher.dispatched.len(), 2);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params[1], &INPUT[4..(INPUT.len() - 2)]);
+            },
+            _ => panic!("expected osc sequence"),
         }
-
-        assert!(dispatcher.dispatched_dcs);
-        assert_eq!(dispatcher.params, vec![0, 1]);
-        assert_eq!(dispatcher.c, Some('|'));
-        assert_eq!(dispatcher.s, b"17/ab".to_vec());
     }
 
     #[test]
@@ -805,7 +617,7 @@ mod tests {
         static INPUT_START: &[u8] = &[0x1b, b']', b'5', b'2', b';', b's'];
         static INPUT_END: &[u8] = &[b'\x07'];
 
-        let mut dispatcher = OscDispatcher::default();
+        let mut dispatcher = Dispatcher::default();
         let mut parser = Parser::new();
 
         // Create valid OSC escape
@@ -823,16 +635,270 @@ mod tests {
             parser.advance(&mut dispatcher, *byte);
         }
 
-        assert!(dispatcher.dispatched_osc);
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Osc(params, _) => {
+                assert_eq!(params.len(), 2);
+                assert_eq!(params[0], b"52");
 
-        assert_eq!(dispatcher.params.len(), 2);
-        assert_eq!(dispatcher.params[0], b"52");
+                #[cfg(not(feature = "no_std"))]
+                assert_eq!(params[1].len(), NUM_BYTES + INPUT_END.len());
 
-        #[cfg(not(feature = "no_std"))]
-        assert_eq!(dispatcher.params[1].len(), NUM_BYTES + INPUT_END.len());
+                #[cfg(feature = "no_std")]
+                assert_eq!(params[1].len(), MAX_OSC_RAW - params[0].len());
+            },
+            _ => panic!("expected osc sequence"),
+        }
+    }
 
-        #[cfg(feature = "no_std")]
-        assert_eq!(dispatcher.params[1].len(), MAX_OSC_RAW - dispatcher.params[0].len());
+    #[test]
+    fn parse_csi_max_params() {
+        // This will build a list of repeating '1;'s
+        // The length is MAX_PARAMS - 1 because the last semicolon is interpreted
+        // as an implicit zero, making the total number of parameters MAX_PARAMS
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS - 1).collect::<String>();
+        let input = format!("\x1b[{}p", &params[..]).into_bytes();
+
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_ignore_long_params() {
+        // This will build a list of repeating '1;'s
+        // The length is MAX_PARAMS because the last semicolon is interpreted
+        // as an implicit zero, making the total number of parameters MAX_PARAMS + 1
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS).collect::<String>();
+        let input = format!("\x1b[{}p", &params[..]).into_bytes();
+
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_trailing_semicolon() {
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in b"\x1b[4;m" {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[4], [0]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_csi_params_leading_semicolon() {
+        // Create dispatcher and check state
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in b"\x1b[;4m" {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[0], [4]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_long_csi_param() {
+        // The important part is the parameter, which is (i64::MAX + 1)
+        static INPUT: &[u8] = b"\x1b[9223372036854775808m";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, ..) => assert_eq!(params, &[[std::u16::MAX as u16]]),
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn csi_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1b[?1049h";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, intermediates, ignore, _) => {
+                assert_eq!(intermediates, &[b'?']);
+                assert_eq!(params, &[[1049]]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn csi_subparameters() {
+        static INPUT: &[u8] = b"\x1b[38:2:255:0:255;1m";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Csi(params, intermediates, ignore, _) => {
+                assert_eq!(params, &[vec![38, 2, 255, 0, 255], vec![1]]);
+                assert_eq!(intermediates, &[]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected csi sequence"),
+        }
+    }
+
+    #[test]
+    fn parse_dcs_max_params() {
+        let params = std::iter::repeat("1;").take(params::MAX_PARAMS + 1).collect::<String>();
+        let input = format!("\x1bP{}p", &params[..]).into_bytes();
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in input {
+            parser.advance(&mut dispatcher, byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, _, ignore, _) => {
+                assert_eq!(params.len(), params::MAX_PARAMS);
+                assert!(params.iter().all(|param| param == &[1]));
+                assert!(ignore);
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+    }
+
+    #[test]
+    fn dcs_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1bP1$tx\x9c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 3);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, intermediates, ignore, _) => {
+                assert_eq!(intermediates, &[b'$']);
+                assert_eq!(params, &[[1]]);
+                assert!(!ignore);
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+        assert_eq!(dispatcher.dispatched[1], Sequence::DcsPut(b'x'));
+        assert_eq!(dispatcher.dispatched[2], Sequence::DcsUnhook);
+    }
+
+    #[test]
+    fn parse_dcs() {
+        static INPUT: &[u8] = b"\x1bP0;1|17/ab\x9c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 7);
+        match &dispatcher.dispatched[0] {
+            Sequence::DcsHook(params, _, _, c) => {
+                assert_eq!(params, &[[0], [1]]);
+                assert_eq!(c, &'|');
+            },
+            _ => panic!("expected dcs sequence"),
+        }
+        for (i, byte) in b"17/ab".iter().enumerate() {
+            assert_eq!(dispatcher.dispatched[1 + i], Sequence::DcsPut(*byte));
+        }
+        assert_eq!(dispatcher.dispatched[6], Sequence::DcsUnhook);
+    }
+
+    #[test]
+    fn intermediate_reset_on_dcs_exit() {
+        static INPUT: &[u8] = b"\x1bP=1sZZZ\x1b+\x5c";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 6);
+        match &dispatcher.dispatched[5] {
+            Sequence::Esc(intermediates, ..) => assert_eq!(intermediates, &[b'+']),
+            _ => panic!("expected esc sequence"),
+        }
+    }
+
+    #[test]
+    fn esc_reset() {
+        static INPUT: &[u8] = b"\x1b[3;1\x1b(A";
+        let mut dispatcher = Dispatcher::default();
+        let mut parser = Parser::new();
+
+        for byte in INPUT {
+            parser.advance(&mut dispatcher, *byte);
+        }
+
+        assert_eq!(dispatcher.dispatched.len(), 1);
+        match &dispatcher.dispatched[0] {
+            Sequence::Esc(intermediates, ignore, byte) => {
+                assert_eq!(intermediates, &[b'(']);
+                assert_eq!(*byte, b'A');
+                assert!(!ignore);
+            },
+            _ => panic!("expected esc sequence"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@ extern crate alloc;
 
 use core::mem::MaybeUninit;
 
-#[cfg(feature = "no_alloc")]
-use arrayvec::ArrayVec;
 #[cfg(all(not(feature = "no_alloc"), feature = "no_std"))]
 use alloc::vec::Vec;
+#[cfg(feature = "no_alloc")]
+use arrayvec::ArrayVec;
 #[cfg(not(feature = "no_std"))]
 use std::vec::Vec;
 
@@ -161,7 +161,7 @@ impl Parser {
                     Action::None => (),
                     action => {
                         self.perform_action(performer, action, $arg);
-                    },
+                    }
                 }
             };
         }
@@ -170,15 +170,15 @@ impl Parser {
             State::Anywhere => {
                 // Just run the action
                 self.perform_action(performer, action, byte);
-            },
+            }
             state => {
                 match self.state {
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Unhook, byte);
-                    },
+                    }
                     State::OscString => {
                         self.perform_action(performer, Action::OscEnd, byte);
-                    },
+                    }
                     _ => (),
                 }
 
@@ -187,19 +187,19 @@ impl Parser {
                 match state {
                     State::CsiEntry | State::DcsEntry | State::Escape => {
                         self.perform_action(performer, Action::Clear, byte);
-                    },
+                    }
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Hook, byte);
-                    },
+                    }
                     State::OscString => {
                         self.perform_action(performer, Action::OscStart, byte);
-                    },
+                    }
                     _ => (),
                 }
 
                 // Assume the new state
                 self.state = state;
-            },
+            }
         }
     }
 
@@ -236,12 +236,12 @@ impl Parser {
                 }
 
                 performer.hook(self.params(), self.intermediates(), self.ignoring, byte as char);
-            },
+            }
             Action::Put => performer.put(byte),
             Action::OscStart => {
                 self.osc_raw.clear();
                 self.osc_num_params = 0;
-            },
+            }
             Action::OscPut => {
                 #[cfg(feature = "no_alloc")]
                 {
@@ -262,21 +262,21 @@ impl Parser {
                         // First param is special - 0 to current byte index
                         0 => {
                             self.osc_params[param_idx] = (0, idx);
-                        },
+                        }
 
                         // All other params depend on previous indexing
                         _ => {
                             let prev = self.osc_params[param_idx - 1];
                             let begin = prev.1;
                             self.osc_params[param_idx] = (begin, idx);
-                        },
+                        }
                     }
 
                     self.osc_num_params += 1;
                 } else {
                     self.osc_raw.push(byte);
                 }
-            },
+            }
             Action::OscEnd => {
                 let param_idx = self.osc_num_params;
                 let idx = self.osc_raw.len();
@@ -289,7 +289,7 @@ impl Parser {
                     0 => {
                         self.osc_params[param_idx] = (0, idx);
                         self.osc_num_params += 1;
-                    },
+                    }
 
                     // All other params depend on previous indexing
                     _ => {
@@ -297,10 +297,10 @@ impl Parser {
                         let begin = prev.1;
                         self.osc_params[param_idx] = (begin, idx);
                         self.osc_num_params += 1;
-                    },
+                    }
                 }
                 self.osc_dispatch(performer, byte);
-            },
+            }
             Action::Unhook => performer.unhook(),
             Action::CsiDispatch => {
                 if self.params.is_full() {
@@ -315,10 +315,10 @@ impl Parser {
                     self.ignoring,
                     byte as char,
                 );
-            },
+            }
             Action::EscDispatch => {
                 performer.esc_dispatch(self.intermediates(), self.ignoring, byte)
-            },
+            }
             Action::Collect => {
                 if self.intermediate_idx == MAX_INTERMEDIATES {
                     self.ignoring = true;
@@ -326,7 +326,7 @@ impl Parser {
                     self.intermediates[self.intermediate_idx] = byte;
                     self.intermediate_idx += 1;
                 }
-            },
+            }
             Action::Param => {
                 if self.params.is_full() {
                     self.ignoring = true;
@@ -344,7 +344,7 @@ impl Parser {
                     self.param = self.param.saturating_mul(10);
                     self.param = self.param.saturating_add((byte - b'0') as u16);
                 }
-            },
+            }
             Action::Clear => {
                 // Reset everything on ESC/CSI/DCS entry
                 self.intermediate_idx = 0;
@@ -352,7 +352,7 @@ impl Parser {
                 self.param = 0;
 
                 self.params.clear();
-            },
+            }
             Action::BeginUtf8 => self.process_utf8(performer, byte),
             Action::Ignore => (),
             Action::None => (),
@@ -502,7 +502,7 @@ mod tests {
                 assert_eq!(params.len(), 2);
                 assert_eq!(params[0], &OSC_BYTES[2..3]);
                 assert_eq!(params[1], &OSC_BYTES[4..(OSC_BYTES.len() - 1)]);
-            },
+            }
             _ => panic!("expected osc sequence"),
         }
     }
@@ -539,7 +539,7 @@ mod tests {
             Sequence::Osc(params, _) => {
                 assert_eq!(params.len(), MAX_OSC_PARAMS);
                 assert!(params.iter().all(Vec::is_empty));
-            },
+            }
             _ => panic!("expected osc sequence"),
         }
     }
@@ -597,7 +597,7 @@ mod tests {
             Sequence::Osc(params, _) => {
                 assert_eq!(params[0], &[b'2']);
                 assert_eq!(params[1], &INPUT[5..(INPUT.len() - 1)]);
-            },
+            }
             _ => panic!("expected osc sequence"),
         }
     }
@@ -616,7 +616,7 @@ mod tests {
         match &dispatcher.dispatched[0] {
             Sequence::Osc(params, _) => {
                 assert_eq!(params[1], &INPUT[4..(INPUT.len() - 2)]);
-            },
+            }
             _ => panic!("expected osc sequence"),
         }
     }
@@ -656,7 +656,7 @@ mod tests {
 
                 #[cfg(feature = "no_alloc")]
                 assert_eq!(params[1].len(), MAX_OSC_RAW - params[0].len());
-            },
+            }
             _ => panic!("expected osc sequence"),
         }
     }
@@ -681,7 +681,7 @@ mod tests {
             Sequence::Csi(params, _, ignore, _) => {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(!ignore);
-            },
+            }
             _ => panic!("expected csi sequence"),
         }
     }
@@ -706,7 +706,7 @@ mod tests {
             Sequence::Csi(params, _, ignore, _) => {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(ignore);
-            },
+            }
             _ => panic!("expected csi sequence"),
         }
     }
@@ -778,7 +778,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'?']);
                 assert_eq!(params, &[[1049]]);
                 assert!(!ignore);
-            },
+            }
             _ => panic!("expected csi sequence"),
         }
     }
@@ -799,7 +799,7 @@ mod tests {
                 assert_eq!(params, &[vec![38, 2, 255, 0, 255], vec![1]]);
                 assert_eq!(intermediates, &[]);
                 assert!(!ignore);
-            },
+            }
             _ => panic!("expected csi sequence"),
         }
     }
@@ -821,7 +821,7 @@ mod tests {
                 assert_eq!(params.len(), params::MAX_PARAMS);
                 assert!(params.iter().all(|param| param == &[1]));
                 assert!(ignore);
-            },
+            }
             _ => panic!("expected dcs sequence"),
         }
     }
@@ -842,7 +842,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'$']);
                 assert_eq!(params, &[[1]]);
                 assert!(!ignore);
-            },
+            }
             _ => panic!("expected dcs sequence"),
         }
         assert_eq!(dispatcher.dispatched[1], Sequence::DcsPut(b'x'));
@@ -864,7 +864,7 @@ mod tests {
             Sequence::DcsHook(params, _, _, c) => {
                 assert_eq!(params, &[[0], [1]]);
                 assert_eq!(c, &'|');
-            },
+            }
             _ => panic!("expected dcs sequence"),
         }
         for (i, byte) in b"17/ab".iter().enumerate() {
@@ -906,7 +906,7 @@ mod tests {
                 assert_eq!(intermediates, &[b'(']);
                 assert_eq!(*byte, b'A');
                 assert!(!ignore);
-            },
+            }
             _ => panic!("expected esc sequence"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,18 @@
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 #![cfg_attr(feature = "no_std", no_std)]
 
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
 use core::mem::MaybeUninit;
 
-#[cfg(feature = "no_std")]
+#[cfg(feature = "no_alloc")]
 use arrayvec::ArrayVec;
+#[cfg(all(not(feature = "no_alloc"), feature = "no_std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "no_std"))]
+use std::vec::Vec;
+
 use utf8parse as utf8;
 
 mod definitions;
@@ -79,9 +87,9 @@ pub struct Parser {
     intermediate_idx: usize,
     params: Params,
     param: u16,
-    #[cfg(feature = "no_std")]
+    #[cfg(feature = "no_alloc")]
     osc_raw: ArrayVec<[u8; MAX_OSC_RAW]>,
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(not(feature = "no_alloc"))]
     osc_raw: Vec<u8>,
     osc_params: [(usize, usize); MAX_OSC_PARAMS],
     osc_num_params: usize,
@@ -237,7 +245,7 @@ impl Parser {
                 self.osc_num_params = 0;
             },
             Action::OscPut => {
-                #[cfg(feature = "no_std")]
+                #[cfg(feature = "no_alloc")]
                 {
                     if self.osc_raw.is_full() {
                         return;
@@ -832,10 +840,10 @@ mod tests {
         assert_eq!(dispatcher.params.len(), 2);
         assert_eq!(dispatcher.params[0], b"52");
 
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(not(feature = "no_alloc"))]
         assert_eq!(dispatcher.params[1].len(), NUM_BYTES + INPUT_END.len());
 
-        #[cfg(feature = "no_std")]
+        #[cfg(feature = "no_alloc")]
         assert_eq!(dispatcher.params[1].len(), MAX_OSC_RAW - dispatcher.params[0].len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,28 +165,26 @@ impl Parser {
                 match self.state {
                     State::DcsPassthrough => {
                         self.perform_action(performer, Action::Unhook, byte);
-                        maybe_action!(action, byte);
                     },
                     State::OscString => {
                         self.perform_action(performer, Action::OscEnd, byte);
-                        maybe_action!(action, byte);
                     },
-                    _ => {
-                        maybe_action!(action, byte);
+                    _ => (),
+                }
 
-                        match state {
-                            State::CsiEntry | State::DcsEntry | State::Escape => {
-                                self.perform_action(performer, Action::Clear, byte);
-                            },
-                            State::DcsPassthrough => {
-                                self.perform_action(performer, Action::Hook, byte);
-                            },
-                            State::OscString => {
-                                self.perform_action(performer, Action::OscStart, byte);
-                            },
-                            _ => (),
-                        }
+                maybe_action!(action, byte);
+
+                match state {
+                    State::CsiEntry | State::DcsEntry | State::Escape => {
+                        self.perform_action(performer, Action::Clear, byte);
                     },
+                    State::DcsPassthrough => {
+                        self.perform_action(performer, Action::Hook, byte);
+                    },
+                    State::OscString => {
+                        self.perform_action(performer, Action::OscStart, byte);
+                    },
+                    _ => (),
                 }
 
                 // Assume the new state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 #![cfg_attr(feature = "no_std", no_std)]
 
-#[cfg(feature = "no_std")]
+#[cfg(all(not(feature = "no_alloc"), feature = "no_std"))]
 extern crate alloc;
 
 use core::mem::MaybeUninit;


### PR DESCRIPTION
This PR:
- merges changes from upstream
- adds `no_alloc` feature disable all things that need allocator
- syncs up `ansi` module with a [reference implementation](https://github.com/alacritty/alacritty/blob/master/alacritty_terminal/src/ansi.rs) in `alacritty_terminal` crate